### PR TITLE
[refact] Input 컴포넌트 개선

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,8 @@
         "next-themes": "^0.4.6",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-hook-form": "^7.65.0",
+        "react-hot-toast": "^2.6.0",
         "zustand": "^5.0.8",
       },
       "devDependencies": {
@@ -664,6 +666,8 @@
 
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
 
+    "goober": ["goober@2.1.18", "", { "peerDependencies": { "csstype": "^3.0.10" } }, "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw=="],
+
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
@@ -903,6 +907,10 @@
     "react": ["react@19.2.0", "", {}, "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ=="],
 
     "react-dom": ["react-dom@19.2.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ=="],
+
+    "react-hook-form": ["react-hook-form@7.65.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-xtOzDz063WcXvGWaHgLNrNzlsdFgtUWcb32E6WFaGTd7kPZG3EeDusjdZfUsPwKCKVXy1ZlntifaHZ4l8pAsmw=="],
+
+    "react-hot-toast": ["react-hot-toast@2.6.0", "", { "dependencies": { "csstype": "^3.1.3", "goober": "^2.1.16" }, "peerDependencies": { "react": ">=16", "react-dom": ">=16" } }, "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg=="],
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "next-themes": "^0.4.6",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-hook-form": "^7.65.0",
+    "react-hot-toast": "^2.6.0",
     "zustand": "^5.0.8"
   },
   "devDependencies": {

--- a/src/components/Input/Input.css.ts
+++ b/src/components/Input/Input.css.ts
@@ -24,17 +24,19 @@ export const inputWrapper = style({
         'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
       WebkitMaskComposite: 'xor',
       pointerEvents: 'none',
-      opacity: 1, 
+      opacity: 1,
       transition: 'opacity 0.2s ease',
     },
     '&[data-input-focused="true"]::before': {
       opacity: 0,
     },
- 
+
     '&[data-error="true"]::before': {
       opacity: 0,
     },
-    
+    '&[data-variant="secondary"]::before': {
+      opacity: 0,
+    },
   },
 });
 
@@ -70,9 +72,19 @@ export const input = style({
   },
 });
 
+export const inputSecondary = style([
+  input,
+  {
+    padding: '12px 30px',
+    background: tokens.color.surface.raised,
+    color: 'tokens.color.text.body',
+    borderRadius: '50px',
+  },
+]);
+
 export const iconButton = style({
   position: 'absolute',
-  right: '16px',
+  right: '30px',
   display: 'flex',
   background: 'none',
   border: 'none',
@@ -103,39 +115,11 @@ export const iconButton = style({
   },
 });
 
-export const icon = style({
-  width: '24px',
-  height: '24px',
-  position: 'absolute',
-  right: '16px',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  pointerEvents: 'none',
-  color: tokens.color.badge.filled.bg.gray,
-  borderRadius: '4px',
-  transition: 'all 0.2s ease',
-  zIndex: 2,
-
-  selectors: {
-    '&:hover': {
-      color: tokens.color.field.border.focus,
-    },
-    '&:active': {
-      color: tokens.color.field.border.focus,
-    },
-    '&:focus': {
-      outline: `2px solid ${tokens.color.field.border.focus}`,
-      outlineOffset: '2px',
-    },
-  },
-});
-
 export const searchIcon = style({
   width: '24px',
   height: '24px',
   position: 'absolute',
-  right: '16px',
+  right: '30px',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -18,6 +18,7 @@ type InputProps = {
   error?: boolean;
   disabled?: boolean;
   onSearchClick?: () => void;
+  variant?: 'primary' | 'secondary';
 };
 
 export default function Input({
@@ -29,6 +30,7 @@ export default function Input({
   error = false,
   disabled = false,
   onSearchClick,
+  variant = 'primary',
 }: InputProps) {
   const [isInputFocused, setIsInputFocused] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
@@ -132,16 +134,23 @@ export default function Input({
       className={clsx(styles.inputWrapper)}
       data-error={error}
       data-input-focused={isInputFocused}
+      data-variant={variant}
     >
       <input
         ref={inputRef}
-        className={styles.input}
-        type={getInputType()}
+        className={clsx(
+          type === 'search'
+            ? variant === 'secondary'
+              ? styles.inputSecondary
+              : styles.input
+            : styles.input
+        )}
+        type={type === 'password' ? (showPassword ? 'text' : 'password') : type}
         placeholder={placeholder}
         value={value}
         onChange={onChange}
-        onFocus={handleInputFocus}
-        onBlur={handleInputBlur}
+        onFocus={() => setIsInputFocused(true)}
+        onBlur={() => setIsInputFocused(false)}
         aria-invalid={error}
         disabled={disabled}
       />
@@ -152,7 +161,7 @@ export default function Input({
           type="button"
           className={styles.iconButton}
           onClick={handleTogglePassword}
-          onFocus={handleIconFocus}
+          onFocus={() => setIsInputFocused(false)}
           onKeyDown={(e) => handleKeyDown(e, handleTogglePassword)}
           onMouseDown={handleMouseDown}
           aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
@@ -169,18 +178,17 @@ export default function Input({
 
       {type === 'search' && (
         <button
-          ref={searchButtonRef}
           type="button"
           className={styles.searchIcon}
           onClick={handleSearchClick}
-          onFocus={handleIconFocus}
+          onFocus={() => setIsInputFocused(false)}
           onKeyDown={(e) => handleKeyDown(e, handleSearchClick)}
           onMouseDown={handleMouseDown}
           aria-label="검색"
           tabIndex={disabled ? -1 : 0}
           disabled={disabled}
         >
-          <MagnifyingGlassIcon style={{ width: '20px', height: '20px' }} />
+          <MagnifyingGlassIcon style={{ width: 20, height: 20 }} />
         </button>
       )}
     </div>


### PR DESCRIPTION
- 필요 패키지 추가 설치
- variant prop 추가 ('primary' | 'secondary', 기본값 'primary')
- type="search"일 때 variant에 따라 input 스타일 분기
- variant="secondary"면 styles.inputSecondary 적용 아니면 기본 styles.input 적용
- search 아이콘은 variant와 관계없이 항상 동일한 스타일(styles.searchIcon) 사용
- input wrapper에 data-variant={variant} 속성 추가
- inputSecondary 스타일에 상하 패딩 12px, 배경/테두리 등 secondary 스타일 적용
- inputWrapper의 ::before(외곽선) 효과를 data-variant="secondary"일 때 opacity: 0으로 설정 → secondary에서는 외곽선 숨김
- 에러/포커스/variant에 따라 input 및 wrapper 스타일 분기 가능

## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제

---

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)

---

### PR 상세

---

## 이슈

resolves #66 
